### PR TITLE
Override != with <>

### DIFF
--- a/lib/sequel/adapters/drill.rb
+++ b/lib/sequel/adapters/drill.rb
@@ -80,6 +80,8 @@ module Sequel
 
     class Dataset < Sequel::Dataset
       Database::DatasetClass = self
+      LESS_THAN = '<'.freeze
+      GREATER_THAN = '>'.freeze
       
       def fetch_rows(sql)
         # convert Sequel table names to Drill workspace + file
@@ -111,6 +113,18 @@ module Sequel
 
       def supports_window_functions?
         false
+      end
+      
+      def complex_expression_sql_append(sql, op, args)
+        case op
+        when :'!='
+          # Apache Drill doesn't support != as an ne operator, use <> instead
+          literal_append(sql, args.at(0))
+          sql << " " << LESS_THAN << GREATER_THAN << " "
+          literal_append(sql, args.at(1))
+        else
+          super
+        end
       end
 
     end


### PR DESCRIPTION
At the lowest level we want to replace != queries with <>, as Drill doesn't support !=, and nor does Sequel itself as a ComplexExpression (http://sequel.jeremyevans.net/rdoc/classes/Sequel/SQL/ComplexExpression.html). AFAIK with this approach we won't have to change any arbitrary queries or stop using !=, these queries will just be converted to <> at the adapter level.

We could also implement the same thing for Vertica, but there isn't much point since Vertica supports both != and <>

Closes #2 