### PR TITLE
Support aggregate queries (sum, count, avg, min, max)

### DIFF
--- a/lib/sequel/adapters/drill.rb
+++ b/lib/sequel/adapters/drill.rb
@@ -82,8 +82,14 @@ module Sequel
       Database::DatasetClass = self
       
       def fetch_rows(sql)
+        # hacks for Sequel functions without adapter methods intended to be extended/overridden
+        
         # aggregate functions should include backticks
         sql = sql.sub(/^SELECT count\((.+)?\) AS ([[:graph:]]+)?/, "SELECT count(\\1) AS `\\2`")
+        sql = sql.sub(/^SELECT max\((.+)?\) AS ([[:graph:]]+)?/, "SELECT max(\\1) AS `\\2`")
+        sql = sql.sub(/^SELECT min\((.+)?\) AS ([[:graph:]]+)?/, "SELECT min(\\1) AS `\\2`")
+        sql = sql.sub(/^SELECT sum\((.+)?\) AS ([[:graph:]]+)?/, "SELECT sum(\\1) AS `\\2`")
+        sql = sql.sub(/^SELECT avg\((.+)?\) AS ([[:graph:]]+)?/, "SELECT avg(\\1) AS `\\2`")
         
         # convert Sequel table names to Drill workspace + file
         workspace = ENV['DRILL_WORKSPACE'] ||= "tmp"

--- a/lib/sequel/adapters/drill.rb
+++ b/lib/sequel/adapters/drill.rb
@@ -82,6 +82,9 @@ module Sequel
       Database::DatasetClass = self
       
       def fetch_rows(sql)
+        # aggregate functions should include backticks
+        sql = sql.sub(/^SELECT count\((.+)?\) AS ([[:graph:]]+)?/, "SELECT count(\\1) AS `\\2`")
+        
         # convert Sequel table names to Drill workspace + file
         workspace = ENV['DRILL_WORKSPACE'] ||= "tmp"
         # TODO: more precise regex pattern here


### PR DESCRIPTION
Hacks for Sequel functions without adapter methods intended to be extended/overridden. Unfortunately, some hacks are needed here because I cannot find a public adapter method intended for use for this sort of manipulation.