### PR TITLE
Docker-compose update

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "2"
 services:
   gem:
     build: .
-    command: bundle exec rspec
+    command: sleep infinity
     volumes:
       - .:/app
       - bundle:/bundle


### PR DESCRIPTION
This PR is probably not necessary, but I wanted to let you see this to ensure that you are cool with leaving this this way as opposed to writing a script that waits for Drill to become available and then running rspec. I figured that the tests could just be run manually. The tests include actual integration tests where there are actual file changes to the container, which is another reason for this. Perhaps those should be mocked instead...

Closes #7 
