### PR TITLE
Escape aggregation columns with backticks

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,14 @@ For now, the following features are not supported by this adapter:
 
 A Docker image called "drill-hdfs" (link to Dockerhub) has been created for testing purposes, consisting of both Apache Drill and a bare-bones Hadoop service including the HDFS file system. If you wish to use the HDFS file system with Drill for testing purposes, you will need to update Drill's DFS storage plugin config [here](http://localhost:8047/storage/dfs). The "connection" field should be set to `hdfs://localhost:8020/`
 
+### Known issues/caveats/things
+
+* Numbers in Drill are enclosed in quotation marks within its JSON output. If this is an issue you might need to cast within your application, this adapter will not attempt to manipulate output, with one exception (below)
+* Drill normally returns query results in a JSON array entitled "rows" and includes the column names in a JSON array entitled "columns". A lot of applications expect a more conventional SQL-ey output where column names aren't included, so we are omitting the columns in responses returned to ensure greater compability
+* Generated queries are manipulated to do the following:
+  * strip quotation marks
+  * generate Drill workspaces (i.e. dfs.[workspace].[filename])
+  * fix aggregate queries (count/sum/min/max/avg) for Drill compatability
+  * replace `!=` operators with `<>`
+  
+Sorry, the query manipulation is pretty hacky, but it works. Please let me know if you know of a better way to do this.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ For now, the following features are not supported by this adapter:
 
 A Docker image called "drill-hdfs" (link to Dockerhub) has been created for testing purposes, consisting of both Apache Drill and a bare-bones Hadoop service including the HDFS file system. If you wish to use the HDFS file system with Drill for testing purposes, you will need to update Drill's DFS storage plugin config [here](http://localhost:8047/storage/dfs). The "connection" field should be set to `hdfs://localhost:8020/`
 
+If you wish to use the `tmp` workspace you'll also need to create this directory. You can do so as follows:
+
+```
+docker exec -it [drill image id] hdfs dfs -mkdir /tmp
+```
+
 ### Known issues/caveats/things
 
 * Numbers in Drill are enclosed in quotation marks within its JSON output. If this is an issue you might need to cast within your application, this adapter will not attempt to manipulate output, with one exception (below)

--- a/lib/sequel/adapters/drill.rb
+++ b/lib/sequel/adapters/drill.rb
@@ -84,8 +84,14 @@ module Sequel
       GREATER_THAN = '>'.freeze
       
       def fetch_rows(sql)
+        # hacks for Sequel functions without adapter methods intended to be extended/overridden
+        
         # aggregate functions should include backticks
         sql = sql.sub(/^SELECT count\((.+)?\) AS ([[:graph:]]+)?/, "SELECT count(\\1) AS `\\2`")
+        sql = sql.sub(/^SELECT max\((.+)?\) AS ([[:graph:]]+)?/, "SELECT max(\\1) AS `\\2`")
+        sql = sql.sub(/^SELECT min\((.+)?\) AS ([[:graph:]]+)?/, "SELECT min(\\1) AS `\\2`")
+        sql = sql.sub(/^SELECT sum\((.+)?\) AS ([[:graph:]]+)?/, "SELECT sum(\\1) AS `\\2`")
+        sql = sql.sub(/^SELECT avg\((.+)?\) AS ([[:graph:]]+)?/, "SELECT avg(\\1) AS `\\2`")
         
         # convert Sequel table names to Drill workspace + file
         workspace = ENV['DRILL_WORKSPACE'] ||= "tmp"

--- a/lib/sequel/adapters/drill.rb
+++ b/lib/sequel/adapters/drill.rb
@@ -84,6 +84,9 @@ module Sequel
       GREATER_THAN = '>'.freeze
       
       def fetch_rows(sql)
+        # aggregate functions should include backticks
+        sql = sql.sub(/^SELECT count\((.+)?\) AS ([[:graph:]]+)?/, "SELECT count(\\1) AS `\\2`")
+        
         # convert Sequel table names to Drill workspace + file
         workspace = ENV['DRILL_WORKSPACE'] ||= "tmp"
         # TODO: more precise regex pattern here

--- a/spec/adapters/drill_spec.rb
+++ b/spec/adapters/drill_spec.rb
@@ -45,7 +45,18 @@ describe "A drill dataset" do
     'SELECT * FROM "test" WHERE "c1" <> 10'
     )
   end
-  
+
+  specify "Drill workaround: aggregate methods column display names should be escaped with backticks using Drill workspace" do
+    # generated query should be "SELECT count(name) AS `count` FROM dfs.tmp.`test` LIMIT 1"
+    expect(@d.count(:c1)).to eq("3")
+    
+    # test the other methods just for good measure
+    expect(@d.max(:c2)).to eq("66.0")
+    expect(@d.min(:c2)).to eq("11.0")
+    expect(@d.sum(:c2)).to eq("99.0")
+    expect(@d.avg(:c2)).to eq("33.0")
+  end
+
   specify "quotes columns and tables using double quotes if quoting identifiers" do
     expect(@d.select(:name).sql).to eq( \
       'SELECT "name" FROM "test"'


### PR DESCRIPTION
Update Aug 11:

- optimized regex patterns, now supports * and _ characters properly
- quotation marks are replaced with backticks (which should be safe against some sort of SQL injection)

Hacks for Sequel functions without adapter methods intended to be extended/overridden. Unfortunately, this fairly ugly regex approach is needed here because I cannot find a public adapter method intended for use for this sort of manipulation.

On the bright side, I've yet to find a use case that this cannot support, and we are using this same technique to manipulate the Sequel-generated queries to support Drill workspaces...

Closes #4 #15 #14 