### PR TITLE
handle null datasets

### DIFF
--- a/lib/sequel/adapters/drill.rb
+++ b/lib/sequel/adapters/drill.rb
@@ -43,6 +43,11 @@ module Sequel
             # discard column listing to follow Sequel convention
             
             res = res["rows"]
+            
+            # return empty array for empty data sets to follow more common conventions
+            if res.to_json == "[{}]"
+              res = []
+            end
           end
           res.each(&block)
         end


### PR DESCRIPTION
With this change count requests on empty datasets will return as 0 rather than 1. Drill normally returns empty data sets as follows:

```
{
    "columns": [],
    "rows": [
        {}
    ]
}
```

Closes #16 