### PR TITLE
Revamped drop table support

### DIFF
--- a/lib/sequel/adapters/drill.rb
+++ b/lib/sequel/adapters/drill.rb
@@ -1,6 +1,7 @@
 require "sequel"
 require "json"
 require "net/http"
+require "pry"
 
 module Sequel
   extension :core_extensions
@@ -106,9 +107,7 @@ module Sequel
           end
         end
         
-        puts sql
         execute(sql) do |row|
-          puts row
           # TODO: possible hack to cast numbers recorded as JSON strings to numbers?
           yield row.to_h.inject({}) { |a, (k,v)| a[k.to_sym] = v; a }
         end

--- a/lib/sequel/adapters/drill.rb
+++ b/lib/sequel/adapters/drill.rb
@@ -106,7 +106,9 @@ module Sequel
           end
         end
         
+        puts sql
         execute(sql) do |row|
+          puts row
           # TODO: possible hack to cast numbers recorded as JSON strings to numbers?
           yield row.to_h.inject({}) { |a, (k,v)| a[k.to_sym] = v; a }
         end

--- a/lib/sequel/adapters/drill.rb
+++ b/lib/sequel/adapters/drill.rb
@@ -1,7 +1,6 @@
 require "sequel"
 require "json"
 require "net/http"
-require "pry"
 
 module Sequel
   extension :core_extensions


### PR DESCRIPTION
Revamped the warehouse data adapters unit tests to work with the refactored import/parquet file creation, and passing drop table commands directly to sequel-drill (rather than mocking them).

Therefore, this is a take 2 on the last PR except it has been tested properly because it is actually in use now.

Closes #18 