### PR TITLE
Feature/30 - implement drill rest api auth

### DIFF
--- a/lib/sequel-drill.rb
+++ b/lib/sequel-drill.rb
@@ -1,4 +1,5 @@
 require 'sequel-drill/version'
 require 'sequel/adapters/drill'
+require 'sequel/helpers/session'
 
 Sequel::Database::ADAPTERS << 'drill'

--- a/lib/sequel/helpers/session.rb
+++ b/lib/sequel/helpers/session.rb
@@ -1,0 +1,28 @@
+require "singleton"
+
+# keeps an in memory value:session_cookie record
+class Session
+  include Singleton
+
+  attr_reader :sessions
+
+  def get(value)
+    safe_check
+    @sessions[value]
+  end
+
+  def set(value, cookie)
+    safe_check
+    @sessions[value] = cookie
+  end
+
+  def clear
+    @sessions.clear
+  end
+
+  private
+
+  def safe_check
+    @sessions = {} if @sessions.nil?
+  end
+end

--- a/sequel-drill.gemspec
+++ b/sequel-drill.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |gem|
   gem.description   = %q{Sequel adapter for Apache Drill}
   gem.summary       = %q{Sequel adapter for Apache Drill based on sequel-vertica}
   gem.homepage      = "https://github.com/joeauty/sequel-drill"
-  gem.license     = "MIT"
+  gem.license       = "MIT"
 
   gem.requirements  = "Apache Drill (tested on v1.10.x)"
   gem.required_ruby_version = '>= 1.9.3'
@@ -21,6 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rspec" , "~> 3.1"
   gem.add_development_dependency "pry"
   gem.add_development_dependency "webhdfs", "0.8.0"
+  gem.add_development_dependency "http-cookie"
 
   gem.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.files         = `git ls-files`.split("\n")


### PR DESCRIPTION
implements rest api sessions.

- expose `self.authenticate!()` method, which can be called directly. 

Example:

```rb
# It is useful to call this method directly in case of a Drill master dying and losing all sessions.
Sequel::Drill::Database.authenticate!(user, pass, host, port)
```

- updated `.connect()` method to authenticate in the presence of `opts[:user]`

```rb
# will create session if no session is created
c = Sequel.connect(drill_url, user: "user", password: "123") 

begin 
  c.execute("select * from dfs.`/`")
rescue Sequel::Drill:AuthError => e
  
  # in case drill dies and loses sessions
   Sequel::Drill::Database.authenticate!(user, pass, host, port) # will create a in mem session token
end
```

- updated `.execute()` headers to check if any user is authenticated, if so, append session token to request.

cc @brendanstennett @ChrisSandison 