### PR TITLE
make internal error to inherit from sequel db error

### DIFF
--- a/lib/sequel/adapters/drill.rb
+++ b/lib/sequel/adapters/drill.rb
@@ -9,7 +9,7 @@ module Sequel
   module Drill
 
     class AuthError < StandardError; end
-    class DrillInternalError < StandardError; end
+    class DrillInternalError < Sequel::DatabaseError; end
 
     class Database < Sequel::Database
 


### PR DESCRIPTION
so that the error instance has a `wrapped_exception` method